### PR TITLE
Add return statement to IndexScan.getAttributes for clarity

### DIFF
--- a/src/include/qe.h
+++ b/src/include/qe.h
@@ -149,6 +149,7 @@ namespace PeterDB {
             for (Attribute &attribute : attributes) {
                 attribute.name = tableName + "." + attribute.name;
             }
+	    return 0;
         };
 
         ~IndexScan() override {


### PR DESCRIPTION
This PR adds a return 0; statement to the IndexScan.getAttributes function to improve clarity and avoid potential confusion.